### PR TITLE
Use safetyCatch err handlers instead of noop

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const sodium = require('sodium-universal')
 const c = require('compact-encoding')
 const NatSampler = require('nat-sampler')
 const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
 const IO = require('./lib/io')
 const Query = require('./lib/query')
 const Session = require('./lib/session')
@@ -60,7 +61,7 @@ class DHT extends EventEmitter {
     this._onrow = (row) => row.on('full', (node) => this._onfullrow(node, row))
     this._nonePersistentSamples = []
     this._bootstrapping = this._bootstrap()
-    this._bootstrapping.catch(noop)
+    this._bootstrapping.catch(safetyCatch)
 
     this.table.on('row', this._onrow)
 
@@ -264,13 +265,13 @@ class DHT extends EventEmitter {
       const value = b4a.allocUnsafe(2)
       c.uint16.encode({ start: 0, end: 2, buffer: value }, self.io.serverSocket.address().port)
 
-      self._request(data.from, true, PING_NAT, null, value, null, () => { testNat = true }, noop)
+      self._request(data.from, true, PING_NAT, null, value, null, () => { testNat = true }, safetyCatch)
     }
   }
 
   refresh () {
     const node = this.table.random()
-    this._backgroundQuery(node ? node.id : this.table.id).on('error', noop)
+    this._backgroundQuery(node ? node.id : this.table.id).on('error', safetyCatch)
   }
 
   async destroy () {
@@ -807,5 +808,3 @@ function requestAll (dht, internal, command, value, nodes) {
     }
   })
 }
-
-function noop () {}

--- a/lib/io.js
+++ b/lib/io.js
@@ -2,6 +2,7 @@ const FIFO = require('fast-fifo')
 const sodium = require('sodium-universal')
 const c = require('compact-encoding')
 const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
 const peer = require('./peer')
 const {
   INVALID_TOKEN,
@@ -280,7 +281,7 @@ class Request {
     this.destroyed = false
 
     this.oncycle = noop
-    this.onerror = noop
+    this.onerror = safetyCatch
     this.onresponse = noop
 
     this._buffer = null

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,5 +1,6 @@
 const { Readable } = require('streamx')
 const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
 const peer = require('./peer')
 const { DOWN_HINT } = require('./commands')
 
@@ -291,7 +292,7 @@ module.exports = class Query extends Readable {
   _downHint (node, down) {
     const state = { start: 0, end: 6, buffer: b4a.allocUnsafe(6) }
     peer.ipv4.encode(state, down)
-    this.dht._request(node, true, DOWN_HINT, null, state.buffer, this._session, noop, noop)
+    this.dht._request(node, true, DOWN_HINT, null, state.buffer, this._session, noop, safetyCatch)
   }
 
   _pushClosest (m) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fast-fifo": "^1.1.0",
     "kademlia-routing-table": "^1.0.1",
     "nat-sampler": "^1.0.1",
+    "safety-catch": "^1.0.2",
     "sodium-universal": "^4.0.0",
     "streamx": "^2.13.2",
     "time-ordered-set": "^1.0.2",


### PR DESCRIPTION
Re-opening of https://github.com/holepunchto/dht-rpc/pull/73 which got closed when moving the default branch from master to main.

Note: the eighth and last param of `_request` is the onerror handler callback, so I changed those to `safetyCatch`too

(Full signature: `_request (to, internal, command, target, value, session, onresponse, onerror)` )