### PR TITLE
Use dedicated slab for decodeReply buffers

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -2,6 +2,8 @@ const FIFO = require('fast-fifo')
 const sodium = require('sodium-universal')
 const c = require('compact-encoding')
 const b4a = require('b4a')
+const unslab = require('unslab')
+
 const peer = require('./peer')
 const {
   INVALID_TOKEN,
@@ -483,11 +485,16 @@ function decodeReply (from, state) {
     const flags = c.uint.decode(state)
     const tid = c.uint16.decode(state)
     const to = peer.ipv4.decode(state)
-    const id = flags & 1 ? c.fixed32.decode(state) : null
-    const token = flags & 2 ? c.fixed32.decode(state) : null
+    const slabId = flags & 1 ? c.fixed32.decode(state) : null
+    const slabToken = flags & 2 ? c.fixed32.decode(state) : null
     const closerNodes = flags & 4 ? peer.ipv4Array.decode(state) : null
     const error = flags & 8 ? c.uint.decode(state) : 0
-    const value = flags & 16 ? c.buffer.decode(state) : null
+    const slabValue = flags & 16 ? c.buffer.decode(state) : null
+
+    // to, id, token and value are often long-lived, so use dedicated slab to avoid blocking gc
+    // Note: closerNodes[i].id also use slab buffers, but they are assumed to be ephemeral
+    const [id, token, value, toId] = unslab.all([slabId, slabToken, slabValue, to.id])
+    to.id = toId
 
     if (id !== null) from.id = validateId(id, from)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "sodium-universal": "^4.0.0",
     "streamx": "^2.13.2",
     "time-ordered-set": "^1.0.2",
-    "udx-native": "^1.5.3"
+    "udx-native": "^1.5.3",
+    "unslab": "^1.2.0"
   },
   "devDependencies": {
     "brittle": "^3.0.0",

--- a/test.js
+++ b/test.js
@@ -166,7 +166,7 @@ test('commit after query', async function (t) {
 })
 
 test('query yields data with a dedicated memory slab', async function (t) {
-  const swarm = await makeSwarm(5, t)
+  const swarm = await makeSwarm(2, t)
 
   for (const node of swarm) {
     node.on('request', function (req) {

--- a/test.js
+++ b/test.js
@@ -181,9 +181,9 @@ test('query yields data with a dedicated memory slab', async function (t) {
   const reply = q.closestReplies[0]
 
   // Note: no to.id set, so can't test that
-  t.is(reply.token.buffer.byteLength < 100, true, 'no shared slab for token buffer')
-  t.is(reply.from.id.buffer.byteLength < 100, true, 'no shared slab for from.id buffer')
-  t.is(reply.value.buffer.byteLength < 100, true, 'no shared slab for value buffer')
+  t.is(reply.token.buffer.byteLength < 200, true, 'no shared slab for token buffer')
+  t.is(reply.from.id.buffer.byteLength < 200, true, 'no shared slab for from.id buffer')
+  t.is(reply.value.buffer.byteLength < 200, true, 'no shared slab for value buffer')
   t.is(reply.value.buffer, reply.token.buffer, 'value, token and id share the same slab (1/2)')
   t.is(reply.value.buffer, reply.from.id.buffer, 'value, token and id share the same slab (2/2)')
 })


### PR DESCRIPTION
The result of dht replies are often kept around for a long time (for example to populate hypercore's peerInfo objects).

The buffers coming into decodeReply are slab-allocated from udx buffers (~68kb), so large slabs of memory were kept from being garbage collected.

This PR copies the data into a dedicated slab

Note: the buffers of `closestNodes` are not copied out, because those are assumed to be ephemeral

Note: I didn't know how to test the `to.id` field (unsure when it's set)