### PR TITLE
Do not retain slab of peer id's

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -497,6 +497,6 @@ function decodeReply (from, state) {
 }
 
 function validateId (id, from) {
-  const expected = peer.id(from.host, from.port, b4a.allocUnsafeSlow(32))
+  const expected = peer.id(from.host, from.port)
   return b4a.equals(expected, id) ? expected : null
 }

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -17,7 +17,7 @@ const ipv4 = {
 
 module.exports = { id, ipv4, ipv4Array: c.array(ipv4) }
 
-function id (host, port, out = b4a.allocUnsafe(32)) {
+function id (host, port, out = b4a.allocUnsafeSlow(32)) {
   const addr = out.subarray(0, 6)
   ipv4.encode(
     { start: 0, end: 6, buffer: addr },

--- a/test.js
+++ b/test.js
@@ -656,6 +656,11 @@ test('bootstrap with unreachable suggested-IP and fallback to DNS (reachable)', 
   b.destroy()
 })
 
+test('peer ids do not retain a slab', async function (t) {
+  const swarm = await makeSwarm(2, t)
+  t.is(swarm[1].id.buffer.byteLength, 32)
+})
+
 async function freePort () {
   const udx = new UDX()
   const sock = udx.createSocket()


### PR DESCRIPTION
There are some more code paths that use peer.id that retain the slab (on top of validateId), so this PR proposes a simple approach where all peer.id buffers are unslabbed by default.