### PR TITLE
Bugfix command stats: only count internal commands

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -103,7 +103,7 @@ module.exports = class IO {
 
         this.congestion.recv()
 
-        if (req.command < this.stats.commands.length) {
+        if (req.internal && req.command < this.stats.commands.length) {
           this.stats.commands[req.command].rx++
         }
 
@@ -289,7 +289,7 @@ module.exports = class IO {
     this.inflight.push(req)
     if (session) session._attach(req)
 
-    if (command < this.stats.commands.length) {
+    if (internal && command < this.stats.commands.length) {
       this.stats.commands[command].tx++
     }
 


### PR DESCRIPTION
Previously it was also counting non-internal commands, for example the hyperdht commands: https://github.com/holepunchto/hyperdht/blob/0d4f4b65bf1c252487f7fd52ef9e21ac76a3ceba/lib/constants.js#L3-L14

For example, it was counting all FIND_PEER commands (hyperdht command 3) as DOWN_HINT commands (dht rpc command 3)