### PR TITLE
Start push-tag CI before push-main CI

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -1,10 +1,10 @@
 name: Build Status
 on:
   push:
-    branches:
-      - main
     tags: # To trigger the canary
       - '*'
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
That way the checkmark on our landing page corresponds to whether the tests pass on a new release (rather than whether we successfully triggered our canaries)