### PR TITLE
Fix URLs in `package.json` so they are `holepunchto`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mafintosh/dht-rpc.git"
+    "url": "https://github.com/holepunchto/dht-rpc.git"
   },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mafintosh/dht-rpc/issues"
+    "url": "https://github.com/holepunchto/dht-rpc/issues"
   },
-  "homepage": "https://github.com/mafintosh/dht-rpc"
+  "homepage": "https://github.com/holepunchto/dht-rpc#"
 }


### PR DESCRIPTION
Noticed the URLs were incorrect. Probably left over from before it was moved to the `holepunchto` org.