### PR TITLE
Add offline health threshold

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -79,8 +79,7 @@ module.exports = class NetworkHealth {
 
   update() {
     // update counters before dropping oldest
-    if (this.oldest?.offline) this._offlineTicks--
-    else if (this.oldest?.degraded) this._degradedTicks--
+    if (this.oldest?.degraded) this._degradedTicks--
     else if (this.oldest?.degraded === false) this._healthyTicks--
 
     // move window
@@ -100,16 +99,19 @@ module.exports = class NetworkHealth {
 
     // update counters
     if (this.newest.offline) this._offlineTicks++
-    else if (this.newest.degraded) this._degradedTicks++
-    else this._healthyTicks++
+    else {
+      this._offlineTicks = 0
+      if (this.newest.degraded) this._degradedTicks++
+      else this._healthyTicks++
+    }
 
     // check online/offline
-    if (this._offlineTicks >= OFFLINE_THRESHOLD) this.online = false
     if (!this.newest.offline) this.online = true
+    else if (this._offlineTicks >= OFFLINE_THRESHOLD) this.online = false
 
     // check degraded
-    if (this._degradedTicks === MAX_HEALTH_WINDOW) this.degraded = true
     if (!this.online || this._healthyTicks === MAX_HEALTH_WINDOW) this.degraded = false
+    else if (this._degradedTicks === MAX_HEALTH_WINDOW) this.degraded = true
 
     // fire events
     if (this.online && !this.degraded) this._dht._online()

--- a/lib/health.js
+++ b/lib/health.js
@@ -94,13 +94,14 @@ module.exports = class NetworkHealth {
 
     if (this.cold || this.idle) return
 
-    this.newest.degraded = this.timeoutsRate > DEGRADED_TIMEOUT_RATE_THRESHOLD
+    this.online = this.responses > 0
+
+    this.newest.degraded = this.online && this.timeoutsRate > DEGRADED_TIMEOUT_RATE_THRESHOLD
 
     if (this.newest.degraded) this._degradedTicks++
     else this._healthyTicks++
 
-    this.online = this.responses > 0
-    if (this.online && this.allDegraded) this.degraded = true
+    if (this.allDegraded) this.degraded = true
     if (!this.online || this.allHealthy) this.degraded = false
 
     if (this.online && !this.degraded) this._dht._online()

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,4 +1,5 @@
 const MAX_HEALTH_WINDOW = 4
+const OFFLINE_THRESHOLD = 2
 const IDLE_THRESHOLD = 4
 const DEGRADED_TIMEOUT_RATE_THRESHOLD = 0.5
 
@@ -7,6 +8,7 @@ module.exports = class NetworkHealth {
     this._dht = dht
     this._window = []
     this._head = -1
+    this._offlineTicks = 0
     this._degradedTicks = 0
     this._healthyTicks = 0
     this.online = true
@@ -48,14 +50,6 @@ module.exports = class NetworkHealth {
     return this.responses + this.timeouts < IDLE_THRESHOLD
   }
 
-  get allDegraded() {
-    return this._degradedTicks === MAX_HEALTH_WINDOW
-  }
-
-  get allHealthy() {
-    return this._healthyTicks === MAX_HEALTH_WINDOW
-  }
-
   get stats() {
     return {
       online: this.online,
@@ -75,6 +69,7 @@ module.exports = class NetworkHealth {
   reset() {
     this._window = []
     this._head = -1
+    this._offlineTicks = 0
     this._degradedTicks = 0
     this._healthyTicks = 0
     this.online = true
@@ -83,8 +78,9 @@ module.exports = class NetworkHealth {
   }
 
   update() {
-    // update degraded/healthy counters before dropping oldest
-    if (this.oldest?.degraded) this._degradedTicks--
+    // update counters before dropping oldest
+    if (this.oldest?.offline) this._offlineTicks--
+    else if (this.oldest?.degraded) this._degradedTicks--
     else if (this.oldest?.degraded === false) this._healthyTicks--
 
     // move window
@@ -97,15 +93,23 @@ module.exports = class NetworkHealth {
     // skip state changes
     if (this.cold || this.idle) return
 
+    // update newest
+    this.newest.offline = this.responses === 0
+    this.newest.degraded =
+      !this.newest.offline && this.timeoutsRate > DEGRADED_TIMEOUT_RATE_THRESHOLD
+
+    // update counters
+    if (this.newest.offline) this._offlineTicks++
+    else if (this.newest.degraded) this._degradedTicks++
+    else this._healthyTicks++
+
     // check online/offline
-    this.online = this.responses > 0
+    if (this._offlineTicks >= OFFLINE_THRESHOLD) this.online = false
+    if (!this.newest.offline) this.online = true
 
     // check degraded
-    this.newest.degraded = this.online && this.timeoutsRate > DEGRADED_TIMEOUT_RATE_THRESHOLD
-    if (this.newest.degraded) this._degradedTicks++
-    else this._healthyTicks++
-    if (this.allDegraded) this.degraded = true
-    if (!this.online || this.allHealthy) this.degraded = false
+    if (this._degradedTicks === MAX_HEALTH_WINDOW) this.degraded = true
+    if (!this.online || this._healthyTicks === MAX_HEALTH_WINDOW) this.degraded = false
 
     // fire events
     if (this.online && !this.degraded) this._dht._online()

--- a/lib/health.js
+++ b/lib/health.js
@@ -83,27 +83,31 @@ module.exports = class NetworkHealth {
   }
 
   update() {
+    // update degraded/healthy counters before dropping oldest
     if (this.oldest?.degraded) this._degradedTicks--
     else if (this.oldest?.degraded === false) this._healthyTicks--
 
+    // move window
     this._head = this._tail
     this._window[this._head] = {
       responses: this._dht.stats.requests.responses,
       timeouts: this._dht.stats.requests.timeouts
     }
 
+    // skip state changes
     if (this.cold || this.idle) return
 
+    // check online/offline
     this.online = this.responses > 0
 
+    // check degraded
     this.newest.degraded = this.online && this.timeoutsRate > DEGRADED_TIMEOUT_RATE_THRESHOLD
-
     if (this.newest.degraded) this._degradedTicks++
     else this._healthyTicks++
-
     if (this.allDegraded) this.degraded = true
     if (!this.online || this.allHealthy) this.degraded = false
 
+    // fire events
     if (this.online && !this.degraded) this._dht._online()
     else if (this.degraded) this._dht._degraded()
     else this._dht._offline()

--- a/test.js
+++ b/test.js
@@ -1062,6 +1062,21 @@ test('health - offline', async (t) => {
 
   t.is(dht.online, false, 'offline after 2 offline ticks')
 
+  dht.stats.requests.responses += 20
+  dht.health.update()
+
+  t.is(dht.online, true, 'back online after 1 online tick')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.online, true, 'still online after 1 offline tick')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.online, false, 'offline after 2 offline ticks')
+
   t.alike(
     dht.health.stats,
     {
@@ -1101,7 +1116,7 @@ test('health - offline', async (t) => {
   dht.stats.requests.responses += 4
   dht.health.update()
 
-  t.is(dht.online, true, 'back online after single good tick')
+  t.is(dht.online, true, 'back online after 1 online tick')
 
   dht.destroy()
 })
@@ -1201,6 +1216,68 @@ test('health - wakeup', async (t) => {
   t.is(dht.health._window.length, 0, 'window is empty after wakeup')
   t.is(dht.health.cold, true, 'cold after wakeup')
   t.is(dht.online, true, 'still online after wakeup')
+
+  dht.destroy()
+})
+
+test('health - flickers', async (t) => {
+  const dht = createDHT()
+
+  t.alike(
+    dht.health.stats,
+    {
+      online: true,
+      degraded: false,
+      cold: true,
+      idle: true,
+      responses: 0,
+      timeouts: 0,
+      timeoutsRate: 0
+    },
+    'has starting health stats'
+  )
+
+  fillHealthWindow(dht)
+
+  // prime for flickering
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 1, 'added offline tick')
+  t.is(dht.online, true, 'still online after 1 offline tick')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 2, 'added offline tick')
+  t.is(dht.online, false, 'now offline')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 3, 'added offline tick')
+  t.is(dht.online, false, 'still offline')
+
+  // do not flicker
+
+  dht.stats.requests.responses += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 0, 'offline tick reset after online')
+  t.is(dht.online, true, 'back online')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 1, 'added offline tick')
+  t.is(dht.online, true, 'still online after 1 offline tick')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.health._offlineTicks, 2, 'added offline tick')
+  t.is(dht.online, false, 'back offline')
 
   dht.destroy()
 })

--- a/test.js
+++ b/test.js
@@ -1055,7 +1055,12 @@ test('health - offline', async (t) => {
   dht.stats.requests.timeouts += 20
   dht.health.update()
 
-  t.is(dht.online, false, 'offline when no responses & timeouts > sanity')
+  t.is(dht.online, true, 'still online after 1 offline tick')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
+
+  t.is(dht.online, false, 'offline after 2 offline ticks')
 
   t.alike(
     dht.health.stats,
@@ -1075,11 +1080,13 @@ test('health - offline', async (t) => {
 
   dht.health.update()
 
-  t.is(dht.online, false, 'offline when no responses & timeouts > sanity')
   t.is(dht.degraded, false, 'not degraded when offline')
 
   dht.health.reset()
   fillHealthWindow(dht)
+
+  dht.stats.requests.timeouts += 10
+  dht.health.update()
 
   dht.stats.requests.timeouts += 10
   dht.health.update()
@@ -1089,7 +1096,12 @@ test('health - offline', async (t) => {
   dht.stats.requests.responses += 3
   dht.health.update()
 
-  t.is(dht.online, false, 'should stay offline when responses < sanity')
+  t.is(dht.online, false, 'should stay offline when responses < idle threshold')
+
+  dht.stats.requests.responses += 4
+  dht.health.update()
+
+  t.is(dht.online, true, 'back online after single good tick')
 
   dht.destroy()
 })
@@ -1102,6 +1114,9 @@ test('health - resume', async (t) => {
   fillHealthWindow(dht)
 
   t.is(dht.health.cold, false, 'not cold when window full')
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
 
   dht.stats.requests.timeouts += 20
   dht.health.update()
@@ -1133,6 +1148,9 @@ test('health - resume', async (t) => {
   dht.stats.requests.timeouts += 10
   dht.health.update()
 
+  dht.stats.requests.timeouts += 10
+  dht.health.update()
+
   t.is(dht.online, false, 'offline after timeouts and not cold')
 
   dht.health.update()
@@ -1153,6 +1171,9 @@ test('health - wakeup', async (t) => {
   const dht = createDHT()
 
   fillHealthWindow(dht)
+
+  dht.stats.requests.timeouts += 20
+  dht.health.update()
 
   dht.stats.requests.timeouts += 20
   dht.health.update()


### PR DESCRIPTION
The current logic to trigger offline based on just the last tick has proven too aggressive and still flaky sometimes.

This change triggers offline when 2 successive ticks are offline, which is slightly more conservative but necessary to avoid flakiness.

It still quickly reverts back to online if the last tick is online.

