### PR TITLE
Add baseline dht-rpc benchmarks

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,29 @@
+# Benchmarks
+
+This repo includes three local loopback benchmarks for current `dht-rpc` behavior.
+
+## Lookup
+
+```sh
+npm run bench:lookup
+```
+
+Runs [bench/find-node.js](./bench/find-node.js) for steady-state `findNode()` latency and throughput.
+
+## Bootstrap
+
+```sh
+npm run bench:bootstrap
+```
+
+Runs [bench/bootstrap.js](./bench/bootstrap.js) for cold-start swarm bring-up.
+
+## Admission
+
+```sh
+npm run bench:admission
+```
+
+Runs [bench/admission.js](./bench/admission.js) for warm-network join and admission pressure.
+
+For a steadier baseline, prepend `DHT_RPC_BENCH_REPEATS=5`.

--- a/bench/_shared.js
+++ b/bench/_shared.js
@@ -1,0 +1,135 @@
+'use strict'
+
+const { spawn } = require('child_process')
+
+const CHILD_RUN = process.env.DHT_RPC_BENCH_CHILD === '1'
+
+module.exports = {
+  CHILD_RUN,
+  cpuTimeMs,
+  createNode,
+  diffMemory,
+  median,
+  round,
+  runCaseInChild,
+  runRepeatedCases,
+  summarizeDurationSamples,
+  toMb
+}
+
+async function runRepeatedCases(repeats, runChild) {
+  await runChild()
+
+  const runs = []
+
+  for (let round = 1; round <= repeats; round++) {
+    const result = await runChild()
+    result.round = round
+    runs.push(result)
+  }
+
+  return runs
+}
+
+function runCaseInChild(filename) {
+  return new Promise((resolve, reject) => {
+    const stdout = []
+    const stderr = []
+    const child = spawn(process.execPath, ['--expose-gc', filename], {
+      env: {
+        ...process.env,
+        DHT_RPC_BENCH_CHILD: '1'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    child.stdout.on('data', (chunk) => {
+      stdout.push(chunk)
+    })
+
+    child.stderr.on('data', (chunk) => {
+      stderr.push(chunk)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      const output = Buffer.concat(stdout).toString('utf8').trim()
+      const errorOutput = Buffer.concat(stderr).toString('utf8').trim()
+
+      if (code !== 0) {
+        reject(new Error(errorOutput || ('Benchmark child exited with code ' + code)))
+        return
+      }
+
+      const line = output.split('\n').filter(Boolean).at(-1)
+
+      if (!line) {
+        reject(new Error('Benchmark child produced no JSON output'))
+        return
+      }
+
+      try {
+        resolve(JSON.parse(line))
+      } catch (err) {
+        reject(new Error('Failed to parse benchmark child output: ' + line + '\n' + err.message))
+      }
+    })
+  })
+}
+
+function createNode(DHT, opts) {
+  return new DHT({
+    ...opts,
+    host: '127.0.0.1'
+  })
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = sorted.length >> 1
+
+  if ((sorted.length & 1) === 1) return sorted[middle]
+  return (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function diffMemory(after, before) {
+  return {
+    rss: after.rss - before.rss,
+    heapUsed: after.heapUsed - before.heapUsed,
+    external: after.external - before.external,
+    arrayBuffers: after.arrayBuffers - before.arrayBuffers
+  }
+}
+
+function summarizeDurationSamples(samples, { elapsedNs, rateCount = samples.length }) {
+  if (samples.length === 0) {
+    return {
+      elapsedMs: Number(elapsedNs) / 1e6,
+      ratePerSec: rateCount === 0 ? 0 : rateCount / (Number(elapsedNs) / 1e9),
+      avgMs: 0,
+      p95Ms: 0
+    }
+  }
+
+  const totalNs = samples.reduce((sum, value) => sum + value, 0n)
+  const sorted = [...samples].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+
+  return {
+    elapsedMs: Number(elapsedNs) / 1e6,
+    ratePerSec: rateCount === 0 ? 0 : rateCount / (Number(elapsedNs) / 1e9),
+    avgMs: Number(totalNs) / samples.length / 1e6,
+    p95Ms: Number(sorted[Math.max(0, Math.ceil(sorted.length * 0.95) - 1)]) / 1e6
+  }
+}
+
+function cpuTimeMs(cpu) {
+  return (cpu.user + cpu.system) / 1000
+}
+
+function toMb(bytes) {
+  return bytes / (1024 * 1024)
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100
+}

--- a/bench/_shared.js
+++ b/bench/_shared.js
@@ -57,7 +57,7 @@ function runCaseInChild(filename) {
       const errorOutput = Buffer.concat(stderr).toString('utf8').trim()
 
       if (code !== 0) {
-        reject(new Error(errorOutput || ('Benchmark child exited with code ' + code)))
+        reject(new Error(errorOutput || 'Benchmark child exited with code ' + code))
         return
       }
 

--- a/bench/admission.js
+++ b/bench/admission.js
@@ -33,22 +33,6 @@ async function main() {
 
   const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
 
-  console.log('Per-run results')
-  console.table(
-    runs.map((result) => ({
-      round: result.round,
-      baseNodes: result.baseNodes,
-      admissionNodes: result.admissionNodes,
-      admissionAvgMs: round(result.admission.avgMs),
-      admissionP95Ms: round(result.admission.p95Ms),
-      totalElapsedMs: round(result.admission.totalElapsedMs),
-      nodesPerSec: round(result.admission.nodesPerSec),
-      cpuMs: round(result.admission.cpuMs),
-      rssDeltaMb: round(toMb(result.admission.memory.rss)),
-      heapDeltaMb: round(toMb(result.admission.memory.heapUsed))
-    }))
-  )
-
   console.log('Median summary')
   console.table(
     [summarizeRuns(runs)].map((result) => ({

--- a/bench/admission.js
+++ b/bench/admission.js
@@ -17,11 +17,11 @@ const {
 // Warm-network admission benchmark.
 // Default shape:
 // - 64 warm base nodes
-// - 32 additional joining nodes
-// - join concurrency 4
+// - 224 additional joining nodes
+// - join concurrency 6
 const BASE_NODES = Number(process.env.DHT_RPC_BENCH_BASE_NODES || 64)
-const ADMISSION_NODES = Number(process.env.DHT_RPC_BENCH_ADMISSION_NODES || 32)
-const ADMISSION_CONCURRENCY = Number(process.env.DHT_RPC_BENCH_CONCURRENCY || 4)
+const ADMISSION_NODES = Number(process.env.DHT_RPC_BENCH_ADMISSION_NODES || 224)
+const ADMISSION_CONCURRENCY = Number(process.env.DHT_RPC_BENCH_CONCURRENCY || 6)
 const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
 
 async function main() {

--- a/bench/admission.js
+++ b/bench/admission.js
@@ -1,0 +1,147 @@
+'use strict'
+
+const DHT = require('..')
+const {
+  CHILD_RUN,
+  cpuTimeMs,
+  createNode,
+  diffMemory,
+  median,
+  round,
+  runCaseInChild,
+  runRepeatedCases,
+  summarizeDurationSamples,
+  toMb
+} = require('./_shared')
+
+// Warm-network admission benchmark.
+// Default shape:
+// - 64 warm base nodes
+// - 32 additional joining nodes
+// - join concurrency 4
+const BASE_NODES = Number(process.env.DHT_RPC_BENCH_BASE_NODES || 64)
+const ADMISSION_NODES = Number(process.env.DHT_RPC_BENCH_ADMISSION_NODES || 32)
+const ADMISSION_CONCURRENCY = Number(process.env.DHT_RPC_BENCH_CONCURRENCY || 4)
+const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
+
+async function main() {
+  if (CHILD_RUN) {
+    const result = await runCase()
+    process.stdout.write(JSON.stringify(result) + '\n')
+    return
+  }
+
+  const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
+
+  console.log('Per-run results')
+  console.table(
+    runs.map((result) => ({
+      round: result.round,
+      baseNodes: result.baseNodes,
+      admissionNodes: result.admissionNodes,
+      admissionAvgMs: round(result.admission.avgMs),
+      admissionP95Ms: round(result.admission.p95Ms),
+      totalElapsedMs: round(result.admission.totalElapsedMs),
+      nodesPerSec: round(result.admission.nodesPerSec),
+      cpuMs: round(result.admission.cpuMs),
+      rssDeltaMb: round(toMb(result.admission.memory.rss)),
+      heapDeltaMb: round(toMb(result.admission.memory.heapUsed))
+    }))
+  )
+
+  console.log('Median summary')
+  console.table(
+    [summarizeRuns(runs)].map((result) => ({
+      runs: result.runs,
+      baseNodes: result.baseNodes,
+      admissionNodes: result.admissionNodes,
+      admissionAvgMsMedian: round(result.admissionAvgMsMedian),
+      admissionP95MsMedian: round(result.admissionP95MsMedian),
+      totalElapsedMsMedian: round(result.totalElapsedMsMedian),
+      nodesPerSecMedian: round(result.nodesPerSecMedian),
+      cpuMsMedian: round(result.cpuMsMedian),
+      rssDeltaMbMedian: round(result.rssDeltaMbMedian),
+      heapDeltaMbMedian: round(result.heapDeltaMbMedian)
+    }))
+  )
+}
+
+async function runCase() {
+  const base = []
+  const admitted = []
+
+  try {
+    const bootstrapper = createNode(DHT, { ephemeral: false, firewalled: false })
+    await bootstrapper.fullyBootstrapped()
+    base.push(bootstrapper)
+
+    const bootstrap = ['localhost:' + bootstrapper.address().port]
+
+    while (base.length < BASE_NODES) {
+      const node = createNode(DHT, { ephemeral: false, bootstrap })
+      await node.fullyBootstrapped()
+      base.push(node)
+    }
+
+    if (global.gc) global.gc()
+    const memoryBefore = process.memoryUsage()
+    const cpuBefore = process.cpuUsage()
+    const started = process.hrtime.bigint()
+    const latencies = new Array(ADMISSION_NODES)
+
+    await Promise.all(
+      Array.from({ length: ADMISSION_CONCURRENCY }, (_, worker) => workerLoop(worker))
+    )
+
+    const elapsedNs = process.hrtime.bigint() - started
+    const cpu = process.cpuUsage(cpuBefore)
+    if (global.gc) global.gc()
+    const memoryAfter = process.memoryUsage()
+    const stats = summarizeDurationSamples(latencies, { elapsedNs, rateCount: ADMISSION_NODES })
+
+    return {
+      baseNodes: BASE_NODES,
+      admissionNodes: ADMISSION_NODES,
+      admission: {
+        totalElapsedMs: stats.elapsedMs,
+        nodesPerSec: stats.ratePerSec,
+        avgMs: stats.avgMs,
+        p95Ms: stats.p95Ms,
+        cpuMs: cpuTimeMs(cpu),
+        memory: diffMemory(memoryAfter, memoryBefore)
+      }
+    }
+
+    async function workerLoop(worker) {
+      for (let i = worker; i < ADMISSION_NODES; i += ADMISSION_CONCURRENCY) {
+        const nodeStarted = process.hrtime.bigint()
+        const node = createNode(DHT, { ephemeral: false, bootstrap })
+        await node.fullyBootstrapped()
+        latencies[i] = process.hrtime.bigint() - nodeStarted
+        admitted.push(node)
+      }
+    }
+  } finally {
+    await Promise.allSettled([...admitted, ...base].map((node) => node.destroy()))
+  }
+}
+
+function summarizeRuns(runs) {
+  return {
+    runs: runs.length,
+    baseNodes: runs[0].baseNodes,
+    admissionNodes: runs[0].admissionNodes,
+    admissionAvgMsMedian: median(runs.map((result) => result.admission.avgMs)),
+    admissionP95MsMedian: median(runs.map((result) => result.admission.p95Ms)),
+    totalElapsedMsMedian: median(runs.map((result) => result.admission.totalElapsedMs)),
+    nodesPerSecMedian: median(runs.map((result) => result.admission.nodesPerSec)),
+    cpuMsMedian: median(runs.map((result) => result.admission.cpuMs)),
+    rssDeltaMbMedian: median(runs.map((result) => toMb(result.admission.memory.rss))),
+    heapDeltaMbMedian: median(runs.map((result) => toMb(result.admission.memory.heapUsed)))
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/bench/bootstrap.js
+++ b/bench/bootstrap.js
@@ -30,21 +30,6 @@ async function main() {
 
   const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
 
-  console.log('Per-run results')
-  console.table(
-    runs.map((result) => ({
-      round: result.round,
-      nodes: result.nodes,
-      bootstrapAvgMs: round(result.bootstrap.avgMs),
-      bootstrapP95Ms: round(result.bootstrap.p95Ms),
-      totalElapsedMs: round(result.bootstrap.totalElapsedMs),
-      nodesPerSec: round(result.bootstrap.nodesPerSec),
-      cpuMs: round(result.bootstrap.cpuMs),
-      rssDeltaMb: round(toMb(result.bootstrap.memory.rss)),
-      heapDeltaMb: round(toMb(result.bootstrap.memory.heapUsed))
-    }))
-  )
-
   console.log('Median summary')
   console.table(
     [summarizeRuns(runs)].map((result) => ({

--- a/bench/bootstrap.js
+++ b/bench/bootstrap.js
@@ -1,0 +1,129 @@
+'use strict'
+
+const DHT = require('..')
+const {
+  CHILD_RUN,
+  cpuTimeMs,
+  createNode,
+  diffMemory,
+  median,
+  round,
+  runCaseInChild,
+  runRepeatedCases,
+  summarizeDurationSamples,
+  toMb
+} = require('./_shared')
+
+// Cold-start swarm bring-up benchmark.
+// Default shape:
+// - 64 total local nodes
+// - 1 bootstrapper plus 63 additional joining nodes
+const NODE_COUNT = Number(process.env.DHT_RPC_BENCH_NODES || 64)
+const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
+
+async function main() {
+  if (CHILD_RUN) {
+    const result = await runCase()
+    process.stdout.write(JSON.stringify(result) + '\n')
+    return
+  }
+
+  const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
+
+  console.log('Per-run results')
+  console.table(
+    runs.map((result) => ({
+      round: result.round,
+      nodes: result.nodes,
+      bootstrapAvgMs: round(result.bootstrap.avgMs),
+      bootstrapP95Ms: round(result.bootstrap.p95Ms),
+      totalElapsedMs: round(result.bootstrap.totalElapsedMs),
+      nodesPerSec: round(result.bootstrap.nodesPerSec),
+      cpuMs: round(result.bootstrap.cpuMs),
+      rssDeltaMb: round(toMb(result.bootstrap.memory.rss)),
+      heapDeltaMb: round(toMb(result.bootstrap.memory.heapUsed))
+    }))
+  )
+
+  console.log('Median summary')
+  console.table(
+    [summarizeRuns(runs)].map((result) => ({
+      runs: result.runs,
+      nodes: result.nodes,
+      bootstrapAvgMsMedian: round(result.bootstrapAvgMsMedian),
+      bootstrapP95MsMedian: round(result.bootstrapP95MsMedian),
+      totalElapsedMsMedian: round(result.totalElapsedMsMedian),
+      nodesPerSecMedian: round(result.nodesPerSecMedian),
+      cpuMsMedian: round(result.cpuMsMedian),
+      rssDeltaMbMedian: round(result.rssDeltaMbMedian),
+      heapDeltaMbMedian: round(result.heapDeltaMbMedian)
+    }))
+  )
+}
+
+async function runCase() {
+  const nodes = []
+  let bootstrapper = null
+
+  try {
+    bootstrapper = createNode(DHT, { ephemeral: false, firewalled: false })
+
+    const cpuBefore = process.cpuUsage()
+    if (global.gc) global.gc()
+    const memoryBefore = process.memoryUsage()
+    const started = process.hrtime.bigint()
+
+    await bootstrapper.fullyBootstrapped()
+    nodes.push(bootstrapper)
+
+    const bootstrap = ['localhost:' + bootstrapper.address().port]
+    const latencies = []
+
+    while (nodes.length < NODE_COUNT) {
+      const nodeStarted = process.hrtime.bigint()
+      const node = createNode(DHT, { ephemeral: false, bootstrap })
+      await node.fullyBootstrapped()
+      latencies.push(process.hrtime.bigint() - nodeStarted)
+      nodes.push(node)
+    }
+
+    const elapsedNs = process.hrtime.bigint() - started
+    const cpu = process.cpuUsage(cpuBefore)
+    if (global.gc) global.gc()
+    const memoryAfter = process.memoryUsage()
+    const stats = summarizeDurationSamples(latencies, { elapsedNs, rateCount: NODE_COUNT })
+
+    return {
+      nodes: NODE_COUNT,
+      bootstrap: {
+        totalElapsedMs: stats.elapsedMs,
+        nodesPerSec: stats.ratePerSec,
+        avgMs: stats.avgMs,
+        p95Ms: stats.p95Ms,
+        cpuMs: cpuTimeMs(cpu),
+        memory: diffMemory(memoryAfter, memoryBefore)
+      }
+    }
+  } finally {
+    await Promise.allSettled(nodes.map((node) => node.destroy()))
+  }
+}
+
+function summarizeRuns(runs) {
+  return {
+    runs: runs.length,
+    nodes: runs[0].nodes,
+    bootstrapAvgMsMedian: median(runs.map((result) => result.bootstrap.avgMs)),
+    bootstrapP95MsMedian: median(runs.map((result) => result.bootstrap.p95Ms)),
+    totalElapsedMsMedian: median(runs.map((result) => result.bootstrap.totalElapsedMs)),
+    nodesPerSecMedian: median(runs.map((result) => result.bootstrap.nodesPerSec)),
+    cpuMsMedian: median(runs.map((result) => result.bootstrap.cpuMs)),
+    rssDeltaMbMedian: median(runs.map((result) => toMb(result.bootstrap.memory.rss))),
+    heapDeltaMbMedian: median(runs.map((result) => toMb(result.bootstrap.memory.heapUsed)))
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/bench/bootstrap.js
+++ b/bench/bootstrap.js
@@ -16,9 +16,9 @@ const {
 
 // Cold-start swarm bring-up benchmark.
 // Default shape:
-// - 64 total local nodes
-// - 1 bootstrapper plus 63 additional joining nodes
-const NODE_COUNT = Number(process.env.DHT_RPC_BENCH_NODES || 64)
+// - 256 total local nodes
+// - 1 bootstrapper plus 255 additional joining nodes
+const NODE_COUNT = Number(process.env.DHT_RPC_BENCH_NODES || 256)
 const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
 
 async function main() {

--- a/bench/find-node.js
+++ b/bench/find-node.js
@@ -36,21 +36,6 @@ async function main() {
 
   const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
 
-  console.log('Per-run results')
-  console.table(
-    runs.map((result) => ({
-      round: result.round,
-      nodes: result.nodes,
-      latencyAvgMs: round(result.latency.avgMs),
-      latencyP95Ms: round(result.latency.p95Ms),
-      throughputLookupsPerSec: round(result.throughput.lookupsPerSec),
-      throughputAvgMs: round(result.throughput.avgMs),
-      cpuMs: round(result.throughput.cpuMs),
-      rssDeltaMb: round(toMb(result.throughput.memory.rss)),
-      heapDeltaMb: round(toMb(result.throughput.memory.heapUsed))
-    }))
-  )
-
   console.log('Median summary')
   console.table(
     [summarizeRuns(runs)].map((result) => ({

--- a/bench/find-node.js
+++ b/bench/find-node.js
@@ -17,13 +17,13 @@ const {
 // Steady-state lookup benchmark.
 // Default shape:
 // - 96-node warm local swarm
-// - 20 warmup lookups
-// - 80 sequential lookups for latency
-// - 240 concurrent lookups for throughput at concurrency 12
+// - 50 warmup lookups
+// - 240 sequential lookups for latency
+// - 1600 concurrent lookups for throughput at concurrency 12
 const NODE_COUNT = Number(process.env.DHT_RPC_BENCH_NODES || 96)
-const WARMUP_LOOKUPS = Number(process.env.DHT_RPC_BENCH_WARMUP_LOOKUPS || 20)
-const LATENCY_LOOKUPS = Number(process.env.DHT_RPC_BENCH_LATENCY_LOOKUPS || 80)
-const THROUGHPUT_LOOKUPS = Number(process.env.DHT_RPC_BENCH_THROUGHPUT_LOOKUPS || 240)
+const WARMUP_LOOKUPS = Number(process.env.DHT_RPC_BENCH_WARMUP_LOOKUPS || 50)
+const LATENCY_LOOKUPS = Number(process.env.DHT_RPC_BENCH_LATENCY_LOOKUPS || 240)
+const THROUGHPUT_LOOKUPS = Number(process.env.DHT_RPC_BENCH_THROUGHPUT_LOOKUPS || 1600)
 const THROUGHPUT_CONCURRENCY = Number(process.env.DHT_RPC_BENCH_CONCURRENCY || 12)
 const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
 

--- a/bench/find-node.js
+++ b/bench/find-node.js
@@ -1,0 +1,172 @@
+'use strict'
+
+const DHT = require('..')
+const {
+  CHILD_RUN,
+  cpuTimeMs,
+  createNode,
+  diffMemory,
+  median,
+  round,
+  runCaseInChild,
+  runRepeatedCases,
+  summarizeDurationSamples,
+  toMb
+} = require('./_shared')
+
+// Steady-state lookup benchmark.
+// Default shape:
+// - 96-node warm local swarm
+// - 20 warmup lookups
+// - 80 sequential lookups for latency
+// - 240 concurrent lookups for throughput at concurrency 12
+const NODE_COUNT = Number(process.env.DHT_RPC_BENCH_NODES || 96)
+const WARMUP_LOOKUPS = Number(process.env.DHT_RPC_BENCH_WARMUP_LOOKUPS || 20)
+const LATENCY_LOOKUPS = Number(process.env.DHT_RPC_BENCH_LATENCY_LOOKUPS || 80)
+const THROUGHPUT_LOOKUPS = Number(process.env.DHT_RPC_BENCH_THROUGHPUT_LOOKUPS || 240)
+const THROUGHPUT_CONCURRENCY = Number(process.env.DHT_RPC_BENCH_CONCURRENCY || 12)
+const REPEATS = Number(process.env.DHT_RPC_BENCH_REPEATS || 5)
+
+async function main() {
+  if (CHILD_RUN) {
+    const result = await runCase()
+    process.stdout.write(JSON.stringify(result) + '\n')
+    return
+  }
+
+  const runs = await runRepeatedCases(REPEATS, () => runCaseInChild(__filename))
+
+  console.log('Per-run results')
+  console.table(
+    runs.map((result) => ({
+      round: result.round,
+      nodes: result.nodes,
+      latencyAvgMs: round(result.latency.avgMs),
+      latencyP95Ms: round(result.latency.p95Ms),
+      throughputLookupsPerSec: round(result.throughput.lookupsPerSec),
+      throughputAvgMs: round(result.throughput.avgMs),
+      cpuMs: round(result.throughput.cpuMs),
+      rssDeltaMb: round(toMb(result.throughput.memory.rss)),
+      heapDeltaMb: round(toMb(result.throughput.memory.heapUsed))
+    }))
+  )
+
+  console.log('Median summary')
+  console.table(
+    [summarizeRuns(runs)].map((result) => ({
+      runs: result.runs,
+      nodes: result.nodes,
+      latencyAvgMsMedian: round(result.latencyAvgMsMedian),
+      latencyP95MsMedian: round(result.latencyP95MsMedian),
+      throughputLookupsPerSecMedian: round(result.throughputLookupsPerSecMedian),
+      throughputAvgMsMedian: round(result.throughputAvgMsMedian),
+      cpuMsMedian: round(result.cpuMsMedian),
+      rssDeltaMbMedian: round(result.rssDeltaMbMedian),
+      heapDeltaMbMedian: round(result.heapDeltaMbMedian)
+    }))
+  )
+}
+
+async function runCase() {
+  const swarm = await makeSwarm(NODE_COUNT)
+
+  try {
+    await runLookups(swarm, WARMUP_LOOKUPS, 4)
+
+    if (global.gc) global.gc()
+    const latency = await runLookups(swarm, LATENCY_LOOKUPS, 1)
+
+    if (global.gc) global.gc()
+    const memoryBefore = process.memoryUsage()
+    const cpuBefore = process.cpuUsage()
+    const throughput = await runLookups(swarm, THROUGHPUT_LOOKUPS, THROUGHPUT_CONCURRENCY)
+    const cpu = process.cpuUsage(cpuBefore)
+    if (global.gc) global.gc()
+    const memoryAfter = process.memoryUsage()
+
+    throughput.cpuMs = cpuTimeMs(cpu)
+    throughput.memory = diffMemory(memoryAfter, memoryBefore)
+
+    return {
+      nodes: NODE_COUNT,
+      latency,
+      throughput
+    }
+  } finally {
+    await Promise.allSettled(swarm.map((node) => node.destroy()))
+  }
+}
+
+async function runLookups(swarm, count, concurrency) {
+  const latencies = new Array(count)
+  const started = process.hrtime.bigint()
+
+  await Promise.all(
+    Array.from({ length: concurrency }, (_, worker) => workerLoop(worker, concurrency))
+  )
+
+  const elapsedNs = process.hrtime.bigint() - started
+  const stats = summarizeDurationSamples(latencies, { elapsedNs, rateCount: count })
+
+  return {
+    count,
+    concurrency,
+    elapsedMs: stats.elapsedMs,
+    lookupsPerSec: stats.ratePerSec,
+    avgMs: stats.avgMs,
+    p95Ms: stats.p95Ms
+  }
+
+  async function workerLoop(worker, step) {
+    for (let i = worker; i < count; i += step) {
+      const source = swarm[(i * 17 + 3) % swarm.length]
+      let target = swarm[(i * 31 + 11) % swarm.length]
+
+      if (target === source) {
+        target = swarm[(i * 31 + 12) % swarm.length]
+      }
+
+      const startedAt = process.hrtime.bigint()
+      const query = source.findNode(target.table.id)
+
+      await query.finished()
+
+      latencies[i] = process.hrtime.bigint() - startedAt
+    }
+  }
+}
+
+async function makeSwarm(count) {
+  const first = createNode(DHT, { ephemeral: false, firewalled: false })
+  await first.fullyBootstrapped()
+
+  const bootstrap = ['localhost:' + first.address().port]
+  const nodes = [first]
+
+  while (nodes.length < count) {
+    const node = createNode(DHT, { ephemeral: false, bootstrap })
+    await node.fullyBootstrapped()
+    nodes.push(node)
+  }
+
+  return nodes
+}
+
+function summarizeRuns(runs) {
+  return {
+    runs: runs.length,
+    nodes: runs[0].nodes,
+    latencyAvgMsMedian: median(runs.map((result) => result.latency.avgMs)),
+    latencyP95MsMedian: median(runs.map((result) => result.latency.p95Ms)),
+    throughputLookupsPerSecMedian: median(runs.map((result) => result.throughput.lookupsPerSec)),
+    throughputAvgMsMedian: median(runs.map((result) => result.throughput.avgMs)),
+    cpuMsMedian: median(runs.map((result) => result.throughput.cpuMs)),
+    rssDeltaMbMedian: median(runs.map((result) => toMb(result.throughput.memory.rss))),
+    heapDeltaMbMedian: median(runs.map((result) => toMb(result.throughput.memory.heapUsed)))
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "test-suspend": "^1.0.0"
   },
   "scripts": {
+    "bench:admission": "node --expose-gc bench/admission.js",
+    "bench:bootstrap": "node --expose-gc bench/bootstrap.js",
+    "bench:lookup": "node --expose-gc bench/find-node.js",
     "format": "prettier --write .",
     "test": "npm run test:node && npm run test:bare",
     "test:bare": "brittle-bare --coverage test.js",


### PR DESCRIPTION
## Summary

This PR adds 3 benchmark commands for baseline local `dht-rpc` performance.

Sample medians below are local loopback results from my machine using each command's default settings.

The purpose of adding this is to understand the current performance and build a potential base for future `native` modules that could improve performance.

PR was co-written with AI

## Lookup

Measures steady-state `findNode()` latency and throughput.

```sh
npm run bench:lookup
```

Default settings: `96` nodes, `50` warmup lookups, `240` sequential latency lookups, `1600` throughput lookups at concurrency `12`.

| Metric | Median |
| --- | ---: |
| Avg latency (ms) | 1.75 |
| P95 latency (ms) | 3.15 |
| Throughput (lookups/s) | 658.89 |

## Bootstrap

Measures cold-start swarm bring-up.

```sh
npm run bench:bootstrap
```

Default settings: `256` total nodes, with `1` bootstrapper and `255` joining nodes.

| Metric | Median |
| --- | ---: |
| Total elapsed (ms) | 1513.02 |
| Bootstrap rate (nodes/s) | 169.20 |
| Avg per-node bootstrap (ms) | 5.93 |
| P95 per-node bootstrap (ms) | 9.36 |

## Admission

Measures warm-network join and admission pressure.

```sh
npm run bench:admission
```

Default settings: `64` warm base nodes, `224` joining nodes, concurrency `6`.

| Metric | Median |
| --- | ---: |
| Total elapsed (ms) | 1229.67 |
| Admission rate (nodes/s) | 182.16 |
| Avg per-node admission (ms) | 32.52 |
| P95 per-node admission (ms) | 42.80 |
