### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "adaptive-timeout": "^1.0.1",
     "b4a": "^1.6.1",
     "bare-events": "^2.2.0",
-    "compact-encoding": "^2.11.0",
+    "compact-encoding": "^3.0.0",
     "compact-encoding-net": "^1.2.0",
     "fast-fifo": "^1.1.0",
     "kademlia-routing-table": "^1.0.1",


### PR DESCRIPTION
Didn't change `buffer` encodings in `lib/io.js` because they are always null checked via `flags`.

Depends on the following to be fully updated to `3.0.0`:

- https://github.com/holepunchto/compact-encoding-net/pull/6